### PR TITLE
2 new rules

### DIFF
--- a/lib/uea-stemmer.rb
+++ b/lib/uea-stemmer.rb
@@ -326,6 +326,8 @@ class UEAStemmer
     @rules << EndingRule.new('oded', 1, 61.1)
     @rules << EndingRule.new('ated', 1, 61)
     @rules << CustomRule.new(/.*\w\weds?$/, 2, 62)
+    @rules << EndingRule.new('des', 1, 63.10) # Fix for words like grades, escapades, abodes
+    @rules << EndingRule.new('res', 1, 63.9) # Fix for words like fires, acres, wires, cares
     @rules << EndingRule.new('pes', 1, 63.8)
     @rules << EndingRule.new('mes', 1, 63.7)
     @rules << EndingRule.new('ones', 1, 63.6)

--- a/test/uea_stemmer_test.rb
+++ b/test/uea_stemmer_test.rb
@@ -65,6 +65,20 @@ class UeaStemmerTest < Test::Unit::TestCase
         assert_equal @stemmer.stem('smokes'), 'smoke'
         assert_equal @stemmer.stem('does'), 'do'
       end
+      
+      should "stem various words with -des suffix" do
+        assert_equal @stemmer.stem('abodes'), 'abode'
+        assert_equal @stemmer.stem('escapades'), 'escapade'
+        assert_equal @stemmer.stem('crusades'), 'crusade'
+        assert_equal @stemmer.stem('grades'), 'grade'
+      end
+      
+      should "stem various words with -res suffix" do
+        assert_equal @stemmer.stem('wires'), 'wire'
+        assert_equal @stemmer.stem('acres'), 'acre'
+        assert_equal @stemmer.stem('fires'), 'fire'
+        assert_equal @stemmer.stem('cares'), 'care'
+      end
 
       should "stem acronyms when pluralized otherwise they should be left alone" do
         assert_equal @stemmer.stem('USA'), 'USA'


### PR DESCRIPTION
Rules (and tests) for grades, escapades, abodes and fires, acres, wires, cares. Not 100% sure the rules won't potentially interfere with words that shouldn't be stemmed that way, given the complexity of the English language, but I did run tests on some random stemmed words found at (http://itools.subhashbose.com/wordfind/ending-with). 
