### PR TITLE
Specify license in gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ begin
     gem.email = "jasonmadams@gmail.com"
     gem.homepage = "http://github.com/ealdent/uea-stemmer"
     gem.authors = ["Marie-Claire Jenkins", "Dan J. Smith", "Richard Churchill", "Jason Adams"]
+    gem.license = "Apache-2.0"
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
   end
 


### PR DESCRIPTION
Hi 👋 

The LICENSE specifies that this gem is Apache 2 licensed:

https://github.com/ealdent/uea-stemmer/blob/8b950a1c783e5bf52d6f034565c1bf6efc2a8b26/LICENSE#L2-L3

Including it in gemspec as well makes it easier for various tools to generate reports of all the dependencies in a project and their respective license.

(Note: I haven't tested this change)